### PR TITLE
Remove incorrect API references in synchronize test

### DIFF
--- a/src/synchronize.test.ts
+++ b/src/synchronize.test.ts
@@ -37,10 +37,9 @@ const persisterOperations = {
 
 const testContext = {
   instance: {
-    config: {
-      veracodeApiId: "some-id",
-      veracodeApiSecret: "some-secret",
-    },
+    // synchronize expects a config, but since we mock out the Whitehat client,
+    // it can be empty
+    config: {},
   },
 };
 const executionContext = createTestIntegrationExecutionContext(testContext);


### PR DESCRIPTION
Oopsie. Not going to release this obviously, just fixing while I'm thinking about it.